### PR TITLE
Add image handling in PacketHandler and adjust chunk size in Server

### DIFF
--- a/src/main/java/dev/uday/NET/Packets/ImageHandler.java
+++ b/src/main/java/dev/uday/NET/Packets/ImageHandler.java
@@ -1,0 +1,78 @@
+package dev.uday.NET.Packets;
+
+import dev.uday.Client;
+import dev.uday.NET.Server;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+public class ImageHandler {
+    public static void handleImagePacket(byte[] packetData, UUID sender) {
+        byte msgType = packetData[0];
+        byte[] imageData = Arrays.copyOfRange(packetData, 1, packetData.length);
+        switch (msgType) {
+            case 0:
+                // Handle general image message
+                handleGeneralImageMessage(imageData, sender);
+                break;
+            case 1:
+                // Handle private image message
+                handlePrivateImageMessage(imageData, sender);
+                break;
+        }
+    }
+
+    // Handle general image message
+    private static void handleGeneralImageMessage(byte[] imageData, UUID sender) {
+        byte packetType = 3;
+        byte messageType = 0;
+        String senderUsername = Server.currentClients.get(sender).username;
+        byte[] imagePacket = new byte[imageData.length + 32];
+        imagePacket[0] = packetType;
+        imagePacket[1] = messageType;
+        byte[] senderBytes = senderUsername.getBytes();
+        System.arraycopy(senderBytes, 0, imagePacket, 2, senderBytes.length);
+        // fill remaining bytes with 0
+        for (int i = 2 + senderBytes.length; i < 32; i++) {
+            imagePacket[i] = 0;
+        }
+        System.arraycopy(imageData, 0, imagePacket, 32, imageData.length);
+        // Broadcast the image packet to all clients except the sender
+        for (Client client : Server.currentClients.values()) {
+            if (!client.clientHandler.uuid.equals(sender)) {
+                client.clientHandler.sendPacket(imagePacket);
+            }
+        }
+    }
+
+    // Handle private image message
+    private static void handlePrivateImageMessage(byte[] imageData, UUID sender) {
+        byte[] usernameBytes = new byte[30];
+        System.arraycopy(imageData, 0, usernameBytes, 0, 30);
+        System.out.println("Username bytes: " + Arrays.toString(usernameBytes));
+        String recipientUsername = new String(usernameBytes).trim();
+        byte[] imageBytes = Arrays.copyOfRange(imageData, 30, imageData.length);
+        byte packetType = 3;
+        byte messageType = 1;
+        byte[] imagePacket = new byte[imageBytes.length + 32];
+        imagePacket[0] = packetType;
+        imagePacket[1] = messageType;
+        byte[] senderBytes = Server.currentClients.get(sender).username.getBytes();
+        System.arraycopy(senderBytes, 0, imagePacket, 2, senderBytes.length);
+        // fill remaining bytes with 0
+        for (int i = 2 + senderBytes.length; i < 32; i++) {
+            imagePacket[i] = 0;
+        }
+
+        System.arraycopy(imageBytes, 0, imagePacket, 32, imageBytes.length);
+        // Send the image packet to the specific client
+
+        UUID recipientUUID = Server.getUUIDFromUsername(recipientUsername);
+        if (recipientUUID == null) {
+            System.out.println("Recipient not found: " + recipientUsername );
+            
+        } else {
+            Server.currentClients.get(recipientUUID).clientHandler.sendPacket(imagePacket);
+        }
+    }
+}

--- a/src/main/java/dev/uday/NET/Packets/PacketHandler.java
+++ b/src/main/java/dev/uday/NET/Packets/PacketHandler.java
@@ -16,7 +16,11 @@ public class PacketHandler {
                 System.out.println("Handling message");
                 MessageHandler.handleMessage(packetData, sender);
                 break;
-
+            //Handle image
+            case 3:
+                System.out.println("Handling image");
+                ImageHandler.handleImagePacket(packetData, sender);
+                break;
             //Handle AI prompts
             case 9:
                 System.out.println("Handling AI prompt");

--- a/src/main/java/dev/uday/NET/Server.java
+++ b/src/main/java/dev/uday/NET/Server.java
@@ -81,7 +81,7 @@ public class Server {
     public static class ClientHandler extends Thread {
         private final Socket clientSocket;
         private final PublicKey publicKey;
-        private final UUID uuid;
+        public final UUID uuid;
         private final Cipher cipher;
         private DataInputStream inputStream;
         private DataOutputStream outputStream;
@@ -190,7 +190,7 @@ public class Server {
         public void sendPacket(byte[] bytes) {
             try {
                 // Calculate total number of chunks needed
-                int chunkSize = 350; // Adjust chunk size as needed
+                int chunkSize = 240; // Adjust chunk size as needed
                 int totalChunks = (int) Math.ceil((double) bytes.length / chunkSize);
 
                 // Send header with total packet size and chunk count


### PR DESCRIPTION
This pull request introduces a new `ImageHandler` class to manage image packets, integrates it into the packet handling system, and makes some adjustments to the server's client handler and packet chunk size.

### New Image Handling:

* [`src/main/java/dev/uday/NET/Packets/ImageHandler.java`](diffhunk://#diff-ec54a6dbda7afb56f1e3c3977a7efab1e2ba72efdcd951790f213bf639a7a694R1-R78): Added a new `ImageHandler` class to process general and private image messages.
* [`src/main/java/dev/uday/NET/Packets/PacketHandler.java`](diffhunk://#diff-61cef865d92fbf8567e74f2c14b105a89abb8424f5c78a95b3f123a366ad6f3bL19-R23): Updated `handlePacket` method to include a case for handling image packets using the new `ImageHandler`.

### Server Adjustments:

* [`src/main/java/dev/uday/NET/Server.java`](diffhunk://#diff-46191aaf635f242ca45c174a50872ac535ed5414528a64f6c6d7f8171c457436L84-R84): Changed `uuid` field in `ClientHandler` from private to public to allow access by the `ImageHandler`.
* [`src/main/java/dev/uday/NET/Server.java`](diffhunk://#diff-46191aaf635f242ca45c174a50872ac535ed5414528a64f6c6d7f8171c457436L193-R193): Reduced the chunk size for packet transmission from 350 to 240 bytes to optimize data handling.